### PR TITLE
[bug] 地球页面 国家活动 不可以用判断国家名，应该判断国家code

### DIFF
--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -27,7 +27,7 @@
             <p><a @click="popupPaymentModal()">Pay {{ $API.getNextPrice(landInfo[activeCountryCode]) | price }} to be the new sponsor</a></p>
           </section>
           <h1 class="title">Meetups in <b> {{getCountryName(activeCountryCode)}} </b></h1>
-          <div v-if="getCountryName(activeCountryCode) === 'China'">
+          <div v-if="activeCountryCode === 'CHN'">
             <MeetupBox v-for="(item,key) in meetupList" :key="key" :data="item"></MeetupBox>
           </div>
           <template v-else>


### PR DESCRIPTION
之前活动判断英文国家名，会导致 别的语言国家名无法匹配